### PR TITLE
Add additional filesystem values for ext4/xfs

### DIFF
--- a/lib/puppet/type/partition/fs_type.rb
+++ b/lib/puppet/type/partition/fs_type.rb
@@ -7,13 +7,15 @@ newproperty(:fs_type) do
   newvalues(
     :ext2,
     :ext3,
+    :ext4,
     :fat32,
     :fat16,
     :HFS,
     :'linux-swap',
     :NTFS,
     :reiserfs,
-    :ufs
+    :ufs,
+    :xfs
   )
 
   desc <<-EOT


### PR DESCRIPTION
ext4 and xfs are valid filesystems for RHEL/CentOS 7 and xfs is now the default filesystem.